### PR TITLE
解决getDepotHead查询永远不为空BUG

### DIFF
--- a/jshERP-boot/src/main/java/com/jsh/erp/service/depotHead/DepotHeadService.java
+++ b/jshERP-boot/src/main/java/com/jsh/erp/service/depotHead/DepotHeadService.java
@@ -1210,7 +1210,7 @@ public class DepotHeadService {
     }
 
     public DepotHead getDepotHead(String number)throws Exception {
-        DepotHead depotHead = new DepotHead();
+        DepotHead depotHead = null;
         try{
             DepotHeadExample example = new DepotHeadExample();
             example.createCriteria().andNumberEqualTo(number).andDeleteFlagNotEqualTo(BusinessConstants.DELETE_FLAG_DELETED);


### PR DESCRIPTION
#82 